### PR TITLE
Performance Optimizations for Non-Bulk Indexing

### DIFF
--- a/indexer.py
+++ b/indexer.py
@@ -79,6 +79,7 @@ def is_processable_path(path: str) -> bool:
 def sorted_unique_filepaths(
     file_of_filepaths: Optional[str] = None,
     list_of_filepaths: Optional[List[str]] = None,
+    abspaths: bool = False,
 ) -> List[str]:
     """Return an aggregated, sorted, and set-unique list of filepaths.
 
@@ -86,8 +87,9 @@ def sorted_unique_filepaths(
     in `list_of_filepaths` list. Do not check if filepaths exist.
 
     Keyword Arguments:
-        file_of_filepaths {Optional[str]} -- a file with a filepath on each line (default: {None})
-        list_of_filepaths {Optional[List[str]]} -- a list of filepaths (default: {None})
+        file_of_filepaths -- a file with a filepath on each line
+        list_of_filepaths -- a list of filepaths
+        abspaths -- call `os.path.abspath()` on each filepath
 
     Returns:
         List[str] -- all unique filepaths
@@ -127,6 +129,8 @@ def sorted_unique_filepaths(
                 if path:
                     filepaths.append(path)
 
+    if abspaths:
+        filepaths = [os.path.abspath(p) for p in filepaths]
     filepaths = [f for f in sorted(set(filepaths)) if f]
     return filepaths
 
@@ -470,14 +474,15 @@ def main() -> None:
 
     # Aggregate, sort, and validate filepaths
     paths = sorted_unique_filepaths(
-        file_of_filepaths=args.paths_file, list_of_filepaths=args.paths
+        file_of_filepaths=args.paths_file, list_of_filepaths=args.paths, abspaths=True
     )
-    paths = [os.path.abspath(p) for p in paths]
     for p in paths:  # pylint: disable=C0103
         validate_path(p)
 
     # Read blacklisted paths
-    blacklist = sorted_unique_filepaths(file_of_filepaths=args.blacklist_file)
+    blacklist = sorted_unique_filepaths(
+        file_of_filepaths=args.blacklist_file, abspaths=True
+    )
 
     # Grab and pack args
     rest_client_args: RestClientArgs = {

--- a/indexer.py
+++ b/indexer.py
@@ -20,9 +20,9 @@ from rest_tools.client import RestClient  # type: ignore[import]
 from indexer_api.metadata_manager import MetadataManager
 
 try:
-    from typing import TypedDict, Final
+    from typing import Final, TypedDict
 except ImportError:
-    from typing_extensions import TypedDict, Final  # type: ignore[misc]
+    from typing_extensions import Final, TypedDict  # type: ignore[misc]
 
 
 _DEFAULT_TIMEOUT: Final[int] = 30  # seconds
@@ -451,9 +451,19 @@ def main() -> None:
         help="replace/overwrite any existing File-Catalog entries (aka patch)",
     )
     parser.add_argument(
-        "--blacklist-file", help="blacklist file containing filepaths to skip",
+        "--blacklist",
+        metavar="BLACKPATH",
+        nargs="+",
+        default=None,
+        help="list of blacklisted filepaths; Ex: /foo/bar/ will skip /foo/bar/*",
     )
-    parser.add_argument("-l", "--log", default="DEBUG", help="the output logging level")
+    parser.add_argument(
+        "--blacklist-file",
+        help="a file containing blacklisted filepaths on each line "
+        "(this is a useful alternative to `--blacklist` when there's many blacklisted paths); "
+        "Ex: /foo/bar/ will skip /foo/bar/*",
+    )
+    parser.add_argument("-l", "--log", default="INFO", help="the output logging level")
     parser.add_argument("--iceprodv2-rc-token", default="", help="IceProd2 REST token")
     parser.add_argument("--iceprodv1-db-pass", default="", help="IceProd1 SQL password")
     parser.add_argument(
@@ -479,9 +489,11 @@ def main() -> None:
     for p in paths:  # pylint: disable=C0103
         validate_path(p)
 
-    # Read blacklisted paths
+    # Aggregate & sort blacklisted paths
     blacklist = sorted_unique_filepaths(
-        file_of_filepaths=args.blacklist_file, abspaths=True
+        file_of_filepaths=args.blacklist_file,
+        list_of_filepaths=args.blacklist,
+        abspaths=True,
     )
 
     # Grab and pack args

--- a/indexer_make_dag.py
+++ b/indexer_make_dag.py
@@ -38,7 +38,6 @@ class IndexerArgs(TypedDict):
     iceprodv2_rc_token: str
     iceprodv1_db_pass: str
     dryrun_indexer: bool
-    no_patch: bool
 
 
 # --------------------------------------------------------------------------------------
@@ -115,7 +114,6 @@ def make_condor_file(
 
             # flags
             dryrun = "--dryrun" if indexer_args["dryrun_indexer"] else ""
-            no_patch = "--no-patch" if indexer_args["no_patch"] else ""
 
             # write executable
             executable = make_executable(path_to_virtualenv)
@@ -123,7 +121,7 @@ def make_condor_file(
             # write
             file.write(
                 f"""executable = {os.path.abspath(executable)}
-arguments = python {os.path.abspath(indexer_args['path_to_indexer'])} -s WIPAC --paths-file $(PATHS_FILE) -t {indexer_args['token']} {timeout_retries_args} {blacklist_arg} --log INFO --processes {indexer_args['cpus']} {sim_args} {no_patch} {dryrun}
+arguments = python {os.path.abspath(indexer_args['path_to_indexer'])} -s WIPAC --paths-file $(PATHS_FILE) -t {indexer_args['token']} {timeout_retries_args} {blacklist_arg} --log INFO --processes {indexer_args['cpus']} {sim_args} {dryrun}
 output = {scratch}/$(JOBNUM).out
 error = {scratch}/$(JOBNUM).err
 log = {scratch}/$(JOBNUM).log
@@ -290,13 +288,7 @@ def main() -> None:
         "--dryrun-indexer",
         default=False,
         action="store_true",
-        help="do everything except POSTing/PATCHing to the File Catalog",
-    )
-    parser.add_argument(
-        "--no-patch",
-        default=False,
-        action="store_true",
-        help="do not replace/overwrite existing File-Catalog entries",
+        help="do everything except POSTing to the File Catalog",
     )
     parser.add_argument("--iceprodv2-rc-token", default="", help="IceProd2 REST token")
     parser.add_argument("--iceprodv1-db-pass", default="", help="IceProd1 SQL password")
@@ -333,7 +325,6 @@ def main() -> None:
         "iceprodv2_rc_token": args.iceprodv2_rc_token,
         "iceprodv1_db_pass": args.iceprodv1_db_pass,
         "dryrun_indexer": args.dryrun_indexer,
-        "no_patch": args.no_patch,
     }
     make_condor_file(scratch, args.memory, indexer_args, args.path_to_virtualenv)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,10 @@ coverage==5.0.3
 distro==1.5.0
 docutils==0.16
 fasteners==0.15
+git+https://github.com/WIPACrepo/file_catalog@v1.7.5#egg=file_catalog
+git+https://github.com/WIPACrepo/rest-tools@v1.0.7#egg=rest_tools
+git+https://github.com/WIPACrepo/iceprod@v2.5.6#egg=iceprod
 httplib2==0.18.1
--e git+https://github.com/WIPACrepo/iceprod@94e6cc908f258ec056bde7726ccb51effd3f52ca#egg=iceprod
 idna==2.10
 imagesize==1.2.0
 isort==5.3.0
@@ -37,19 +39,17 @@ pycparser==2.19
 Pygments==2.5.2
 PyNaCl==1.4.0
 pyparsing==2.4.7
-python-dateutil==2.8.1
 pytest
 pytest-flake8
 pytest-mypy
+python-dateutil==2.8.1
 pytz==2020.1
 PyYAML==5.3
 reportlab==3.5.46
-requests==2.24.0
 requests-futures==1.0.0
 requests-mock==1.7.0
 requests-toolbelt==0.9.1
-git+http://github.com/WIPACrepo/file_catalog
-rest_tools @ git+http://github.com/WIPACrepo/rest-tools
+requests==2.24.0
 SecretStorage==3.1.2
 simplejson==3.17.2
 six==1.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ docutils==0.16
 fasteners==0.15
 git+https://github.com/WIPACrepo/file_catalog@v1.7.5#egg=file_catalog
 git+https://github.com/WIPACrepo/rest-tools@v1.0.7#egg=rest_tools
-git+https://github.com/WIPACrepo/iceprod@v2.5.6#egg=iceprod
+git+https://github.com/WIPACrepo/iceprod@v2.5.7#egg=iceprod
 httplib2==0.18.1
 idna==2.10
 imagesize==1.2.0

--- a/tests/unit/indexer/test_path_filtering.py
+++ b/tests/unit/indexer/test_path_filtering.py
@@ -8,7 +8,7 @@ import pytest
 sys.path.append(".")
 from indexer import (  # isort:skip # noqa # pylint: disable=C0413
     ACCEPTED_ROOTS,
-    check_path,
+    validate_path,
     path_in_blacklist,
     sorted_unique_filepaths,
 )
@@ -21,19 +21,19 @@ def test_accepted_roots() -> None:
 
 def test_check_path() -> None:
     """Test filepath white-listing."""
-    check_path("/data/foo")
-    check_path("/data/foo/bar")
-    check_path("/data/")
-    check_path("/data")
+    validate_path("/data/foo")
+    validate_path("/data/foo/bar")
+    validate_path("/data/")
+    validate_path("/data")
 
     with pytest.raises(Exception):
-        check_path("foo")
+        validate_path("foo")
     with pytest.raises(Exception):
-        check_path("/data2")
+        validate_path("/data2")
     with pytest.raises(Exception):
-        check_path("~/data")
+        validate_path("~/data")
     with pytest.raises(Exception):
-        check_path("data/")
+        validate_path("data/")
 
 
 def test_blacklist() -> None:


### PR DESCRIPTION
The indexer was designed for bulk-indexing. However, it may become necessary to point the indexer at a single file (or a small batch). Until now, that would require a not insignificant overhead.

- Replaced `--no-patch` with `--patch`
   + patching is not common
- Check if the file already exists in the FC before collecting its metadata
   + unless given `--patch`, skip the file
   + this will save significant time 
   + also decreases _(but does not eliminate)_ the need for blacklists (`--blacklist-file`)
- Optimize for single-processed indexing (`--processes 1` / the default case)
   + successive child processes are no longer spawned when there's only one process
- Added option for not recursively indexing (`-n`/`--non-recursive`)
   + the indexer will only index the filepaths it's directly given, and will ignore any directories 
   + it's a freeby, so might as well add it
- Added `--blacklist` for shorter blacklists

closes https://github.com/WIPACrepo/file-catalog-indexer/issues/23
closes https://github.com/WIPACrepo/file-catalog-indexer/issues/24