### PR TITLE
Log When File is not Processable

### DIFF
--- a/file_utils.py
+++ b/file_utils.py
@@ -51,7 +51,7 @@ def get_subpaths(filepath: str) -> List[str]:
         is_sym = dir_entry.is_symlink()
         if is_sym:
             logging.warning(
-                f"Nested file is not processable (symbolic link): '{dir_entry}'"
+                f"Skipping nested file -- not processable (symbolic link): '{dir_entry}'"
             )
         return is_sym
 


### PR DESCRIPTION
Now, log a warning-level message for when a file/subdir is skipped because it is not processable.

This mainly occurs when the file/directory is a symbolic link.