### PR TITLE
Fixed args typo for timeout arg

### DIFF
--- a/indexer/index.py
+++ b/indexer/index.py
@@ -528,7 +528,7 @@ if __name__ == "__main__":
         blacklist=args.blacklist,
         blacklist_file=args.blacklist_file,
         url=args.url,
-        timeout=args.token,
+        timeout=args.timeout,
         retries=args.retries,
         basic_only=args.basic_only,
         patch=args.patch,

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,17 +4,17 @@
 #
 #    pip-compile
 #
-backoff==1.10.0
+backoff==1.11.1
     # via opentelemetry-exporter-otlp-proto-http
 bitmath==1.3.3.1
     # via wipac-file-catalog-indexer (setup.py)
-boto3==1.21.40
+boto3==1.23.0
     # via iceprod
-botocore==1.24.40
+botocore==1.26.0
     # via
     #   boto3
     #   s3transfer
-cachetools==5.0.0
+cachetools==5.1.0
     # via iceprod
 certifi==2021.10.8
     # via
@@ -28,17 +28,17 @@ coloredlogs==15.0.1
     # via
     #   wipac-file-catalog
     #   wipac-telemetry
-cryptography==36.0.2
+cryptography==37.0.2
     # via
     #   iceprod
     #   pyopenssl
 deprecated==1.2.13
     # via opentelemetry-api
-googleapis-common-protos==1.56.0
+googleapis-common-protos==1.56.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.44.0
+grpcio==1.46.1
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs
@@ -54,36 +54,36 @@ ldap3==2.9.1
     # via
     #   iceprod
     #   wipac-file-catalog
-motor==2.5.1
+motor==3.0.0
     # via
     #   iceprod
     #   wipac-file-catalog
-opentelemetry-api==1.10.0
+opentelemetry-api==1.11.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   wipac-telemetry
-opentelemetry-exporter-jaeger==1.10.0
+opentelemetry-exporter-jaeger==1.11.1
     # via wipac-telemetry
-opentelemetry-exporter-jaeger-proto-grpc==1.10.0
+opentelemetry-exporter-jaeger-proto-grpc==1.11.1
     # via opentelemetry-exporter-jaeger
-opentelemetry-exporter-jaeger-thrift==1.10.0
+opentelemetry-exporter-jaeger-thrift==1.11.1
     # via opentelemetry-exporter-jaeger
-opentelemetry-exporter-otlp-proto-http==1.10.0
+opentelemetry-exporter-otlp-proto-http==1.11.1
     # via wipac-telemetry
-opentelemetry-proto==1.10.0
+opentelemetry-proto==1.11.1
     # via opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.10.0
+opentelemetry-sdk==1.11.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   wipac-telemetry
-opentelemetry-semantic-conventions==0.29b0
+opentelemetry-semantic-conventions==0.30b1
     # via opentelemetry-sdk
-protobuf==3.20.0
+protobuf==3.20.1
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
@@ -93,9 +93,9 @@ pyasn1==0.4.8
     # via ldap3
 pycparser==2.21
     # via cffi
-pyjwt==2.3.0
+pyjwt==2.4.0
     # via wipac-rest-tools
-pymongo==3.12.3
+pymongo==4.1.1
     # via
     #   iceprod
     #   motor
@@ -133,7 +133,7 @@ requests-toolbelt==0.9.1
     #   wipac-file-catalog-indexer (setup.py)
 s3transfer==0.5.2
     # via boto3
-setproctitle==1.2.2
+setproctitle==1.2.3
     # via iceprod
 six==1.16.0
     # via
@@ -149,7 +149,7 @@ tornado==6.1
     #   iceprod
     #   wipac-file-catalog
     #   wipac-rest-tools
-typing-extensions==4.1.1
+typing-extensions==4.2.0
     # via
     #   opentelemetry-sdk
     #   wipac-file-catalog-indexer (setup.py)
@@ -174,9 +174,9 @@ wipac-rest-tools[telemetry]==1.3.1
     #   wipac-file-catalog-indexer (setup.py)
 wipac-telemetry==0.2.3
     # via wipac-rest-tools
-wrapt==1.14.0
+wrapt==1.14.1
     # via deprecated
-xmltodict==0.12.0
+xmltodict==0.13.0
     # via wipac-file-catalog-indexer (setup.py)
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
@ric-evans Was looking into using the command-line interface of file-catalog-indexer for the Indexer component on jade03.
Found this typo.



