### PR TITLE
Make --dry-run dry again

### DIFF
--- a/indexer/index.py
+++ b/indexer/index.py
@@ -60,6 +60,7 @@ async def _post_metadata(
     if dryrun:
         logging.warning(f"Dry-Run Enabled: Not POSTing to File Catalog! {metadata}")
         sleep(0.1)
+        return
 
     try:
         await fc_rc.request("POST", "/api/files", cast(Dict[str, Any], metadata))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,8 +4,8 @@
 #
 #    pip-compile --extra=dev --output-file=requirements-dev.txt
 #
-anyio==4.0.0
-    # via httpcore
+anyio==4.1.0
+    # via httpx
 asyncache==0.3.1
     # via iceprod
 backoff==2.2.1
@@ -14,18 +14,18 @@ backoff==2.2.1
     #   opentelemetry-exporter-otlp-proto-http
 bitmath==1.3.3.1
     # via wipac-file-catalog-indexer (setup.py)
-boto3==1.28.62
+boto3==1.34.1
     # via iceprod
-botocore==1.31.62
+botocore==1.34.1
     # via
     #   boto3
     #   s3transfer
-cachetools==5.3.1
+cachetools==5.3.2
     # via
     #   asyncache
     #   iceprod
     #   wipac-rest-tools
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   httpcore
     #   httpx
@@ -33,7 +33,7 @@ certifi==2023.7.22
     #   requests
 cffi==1.16.0
     # via cryptography
-charset-normalizer==3.3.0
+charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via
@@ -48,11 +48,13 @@ coloredlogs==15.0.1
     #   wipac-file-catalog
     #   wipac-file-catalog-indexer (setup.py)
     #   wipac-telemetry
-coverage[toml]==7.3.2
-    # via pytest-cov
+coverage[toml]==7.3.3
+    # via
+    #   coverage
+    #   pytest-cov
 crayons==0.4.0
     # via pycycle
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   iceprod
     #   pyjwt
@@ -61,34 +63,34 @@ deprecated==1.2.14
     # via
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-http
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via
     #   anyio
     #   pytest
 flake8==6.1.0
     # via wipac-file-catalog-indexer (setup.py)
-googleapis-common-protos==1.56.2
+googleapis-common-protos==1.59.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.59.0
+grpcio==1.60.0
     # via opentelemetry-exporter-jaeger-proto-grpc
 h11==0.14.0
     # via httpcore
-httpcore==0.18.0
+httpcore==1.0.2
     # via httpx
-httpx==0.25.0
+httpx==0.25.2
     # via iceprod
 humanfriendly==10.0
     # via coloredlogs
-iceprod==2.7.8
+iceprod==2.7.10
     # via wipac-file-catalog-indexer (setup.py)
-idna==3.4
+idna==3.6
     # via
     #   anyio
     #   httpx
     #   requests
-importlib-metadata==6.8.0
+importlib-metadata==6.11.0
     # via opentelemetry-api
 iniconfig==2.0.0
     # via pytest
@@ -112,55 +114,55 @@ motor==2.5.1
     # via
     #   iceprod
     #   wipac-file-catalog
-mypy==1.6.0
+mypy==1.7.1
     # via wipac-file-catalog-indexer (setup.py)
 mypy-extensions==1.0.0
     # via mypy
 natsort==8.4.0
     # via wipac-file-catalog-indexer (setup.py)
-opentelemetry-api==1.20.0
+opentelemetry-api==1.21.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   wipac-telemetry
-opentelemetry-exporter-jaeger==1.20.0
+opentelemetry-exporter-jaeger==1.21.0
     # via wipac-telemetry
-opentelemetry-exporter-jaeger-proto-grpc==1.20.0
+opentelemetry-exporter-jaeger-proto-grpc==1.21.0
     # via opentelemetry-exporter-jaeger
-opentelemetry-exporter-jaeger-thrift==1.20.0
+opentelemetry-exporter-jaeger-thrift==1.21.0
     # via opentelemetry-exporter-jaeger
-opentelemetry-exporter-otlp-proto-common==1.20.0
+opentelemetry-exporter-otlp-proto-common==1.21.0
     # via opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-http==1.20.0
+opentelemetry-exporter-otlp-proto-http==1.21.0
     # via wipac-telemetry
-opentelemetry-proto==1.20.0
+opentelemetry-proto==1.21.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.20.0
+opentelemetry-sdk==1.21.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   wipac-telemetry
-opentelemetry-semantic-conventions==0.41b0
+opentelemetry-semantic-conventions==0.42b0
     # via opentelemetry-sdk
 packaging==23.2
     # via pytest
 pluggy==1.3.0
     # via pytest
-protobuf==3.20.3
+protobuf==4.25.1
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
     #   wipac-telemetry
-psutil==5.9.5
+psutil==5.9.6
     # via iceprod
-pyasn1==0.5.0
+pyasn1==0.5.1
     # via ldap3
-pycodestyle==2.11.0
+pycodestyle==2.11.1
     # via flake8
 pycparser==2.21
     # via cffi
@@ -169,7 +171,9 @@ pycycle==0.0.8
 pyflakes==3.1.0
     # via flake8
 pyjwt[crypto]==2.8.0
-    # via wipac-rest-tools
+    # via
+    #   pyjwt
+    #   wipac-rest-tools
 pymongo==3.13.0
     # via
     #   iceprod
@@ -177,22 +181,22 @@ pymongo==3.13.0
     #   wipac-file-catalog
 pymysql==1.1.0
     # via wipac-file-catalog-indexer (setup.py)
-pyopenssl==23.2.0
+pyopenssl==23.3.0
     # via iceprod
 pypng==0.20220715.0
     # via qrcode
-pytest==7.4.2
+pytest==7.4.3
     # via
     #   pycycle
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-mock
     #   wipac-file-catalog-indexer (setup.py)
-pytest-asyncio==0.21.1
+pytest-asyncio==0.23.2
     # via wipac-file-catalog-indexer (setup.py)
 pytest-cov==4.1.0
     # via wipac-file-catalog-indexer (setup.py)
-pytest-mock==3.11.1
+pytest-mock==3.12.0
     # via wipac-file-catalog-indexer (setup.py)
 python-dateutil==2.8.2
     # via
@@ -226,13 +230,13 @@ requests-toolbelt==1.0.0
     #   iceprod
     #   wipac-file-catalog
     #   wipac-file-catalog-indexer (setup.py)
-ruff==0.0.292
+ruff==0.1.8
     # via wipac-file-catalog-indexer (setup.py)
-s3transfer==0.7.0
+s3transfer==0.9.0
     # via boto3
 setproctitle==1.3.3
     # via iceprod
-shellingham==1.5.3
+shellingham==1.5.4
     # via click-completion
 six==1.16.0
     # via
@@ -243,7 +247,6 @@ six==1.16.0
 sniffio==1.3.0
     # via
     #   anyio
-    #   httpcore
     #   httpx
 statsd==4.0.1
     # via iceprod
@@ -254,7 +257,7 @@ tomli==2.0.1
     #   coverage
     #   mypy
     #   pytest
-tornado==6.3.3
+tornado==6.4
     # via
     #   iceprod
     #   wipac-file-catalog
@@ -263,9 +266,9 @@ types-pymysql==1.1.0.1
     # via wipac-file-catalog-indexer (setup.py)
 types-pyyaml==6.0.12.12
     # via wipac-file-catalog-indexer (setup.py)
-types-requests==2.31.0.8
+types-requests==2.31.0.10
     # via wipac-file-catalog-indexer (setup.py)
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   mypy
     #   opentelemetry-sdk
@@ -275,13 +278,13 @@ typing-extensions==4.8.0
     #   wipac-telemetry
 unidecode==1.3.7
     # via iceprod
-urllib3==2.0.6
+urllib3==2.0.7
     # via
     #   botocore
     #   requests
     #   types-requests
     #   wipac-rest-tools
-wipac-dev-tools==1.7.0
+wipac-dev-tools==1.8.2
     # via
     #   iceprod
     #   wipac-rest-tools
@@ -295,7 +298,7 @@ wipac-rest-tools[telemetry]==1.5.3
     #   wipac-file-catalog-indexer (setup.py)
 wipac-telemetry==0.3.0
     # via wipac-rest-tools
-wrapt==1.15.0
+wrapt==1.16.0
     # via deprecated
 xmltodict==0.13.0
     # via wipac-file-catalog-indexer (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@
 #
 #    pip-compile --output-file=requirements.txt
 #
-anyio==4.0.0
-    # via httpcore
+anyio==4.1.0
+    # via httpx
 asyncache==0.3.1
     # via iceprod
 backoff==2.2.1
@@ -14,18 +14,18 @@ backoff==2.2.1
     #   opentelemetry-exporter-otlp-proto-http
 bitmath==1.3.3.1
     # via wipac-file-catalog-indexer (setup.py)
-boto3==1.28.62
+boto3==1.34.1
     # via iceprod
-botocore==1.31.62
+botocore==1.34.1
     # via
     #   boto3
     #   s3transfer
-cachetools==5.3.1
+cachetools==5.3.2
     # via
     #   asyncache
     #   iceprod
     #   wipac-rest-tools
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   httpcore
     #   httpx
@@ -33,13 +33,13 @@ certifi==2023.7.22
     #   requests
 cffi==1.16.0
     # via cryptography
-charset-normalizer==3.3.0
+charset-normalizer==3.3.2
     # via requests
 coloredlogs==15.0.1
     # via
     #   wipac-file-catalog
     #   wipac-telemetry
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   iceprod
     #   pyjwt
@@ -48,30 +48,30 @@ deprecated==1.2.14
     # via
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-http
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via anyio
-googleapis-common-protos==1.56.2
+googleapis-common-protos==1.59.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.59.0
+grpcio==1.60.0
     # via opentelemetry-exporter-jaeger-proto-grpc
 h11==0.14.0
     # via httpcore
-httpcore==0.18.0
+httpcore==1.0.2
     # via httpx
-httpx==0.25.0
+httpx==0.25.2
     # via iceprod
 humanfriendly==10.0
     # via coloredlogs
-iceprod==2.7.8
+iceprod==2.7.10
     # via wipac-file-catalog-indexer (setup.py)
-idna==3.4
+idna==3.6
     # via
     #   anyio
     #   httpx
     #   requests
-importlib-metadata==6.8.0
+importlib-metadata==6.11.0
     # via opentelemetry-api
 jmespath==1.0.1
     # via
@@ -87,48 +87,50 @@ motor==2.5.1
     # via
     #   iceprod
     #   wipac-file-catalog
-opentelemetry-api==1.20.0
+opentelemetry-api==1.21.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   wipac-telemetry
-opentelemetry-exporter-jaeger==1.20.0
+opentelemetry-exporter-jaeger==1.21.0
     # via wipac-telemetry
-opentelemetry-exporter-jaeger-proto-grpc==1.20.0
+opentelemetry-exporter-jaeger-proto-grpc==1.21.0
     # via opentelemetry-exporter-jaeger
-opentelemetry-exporter-jaeger-thrift==1.20.0
+opentelemetry-exporter-jaeger-thrift==1.21.0
     # via opentelemetry-exporter-jaeger
-opentelemetry-exporter-otlp-proto-common==1.20.0
+opentelemetry-exporter-otlp-proto-common==1.21.0
     # via opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-http==1.20.0
+opentelemetry-exporter-otlp-proto-http==1.21.0
     # via wipac-telemetry
-opentelemetry-proto==1.20.0
+opentelemetry-proto==1.21.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.20.0
+opentelemetry-sdk==1.21.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   wipac-telemetry
-opentelemetry-semantic-conventions==0.41b0
+opentelemetry-semantic-conventions==0.42b0
     # via opentelemetry-sdk
-protobuf==3.20.3
+protobuf==4.25.1
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
     #   wipac-telemetry
-psutil==5.9.5
+psutil==5.9.6
     # via iceprod
-pyasn1==0.5.0
+pyasn1==0.5.1
     # via ldap3
 pycparser==2.21
     # via cffi
 pyjwt[crypto]==2.8.0
-    # via wipac-rest-tools
+    # via
+    #   pyjwt
+    #   wipac-rest-tools
 pymongo==3.13.0
     # via
     #   iceprod
@@ -136,7 +138,7 @@ pymongo==3.13.0
     #   wipac-file-catalog
 pymysql==1.1.0
     # via wipac-file-catalog-indexer (setup.py)
-pyopenssl==23.2.0
+pyopenssl==23.3.0
     # via iceprod
 pypng==0.20220715.0
     # via qrcode
@@ -169,7 +171,7 @@ requests-toolbelt==1.0.0
     #   iceprod
     #   wipac-file-catalog
     #   wipac-file-catalog-indexer (setup.py)
-s3transfer==0.7.0
+s3transfer==0.9.0
     # via boto3
 setproctitle==1.3.3
     # via iceprod
@@ -180,18 +182,17 @@ six==1.16.0
 sniffio==1.3.0
     # via
     #   anyio
-    #   httpcore
     #   httpx
 statsd==4.0.1
     # via iceprod
 thrift==0.16.0
     # via opentelemetry-exporter-jaeger-thrift
-tornado==6.3.3
+tornado==6.4
     # via
     #   iceprod
     #   wipac-file-catalog
     #   wipac-rest-tools
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   opentelemetry-sdk
     #   qrcode
@@ -200,12 +201,12 @@ typing-extensions==4.8.0
     #   wipac-telemetry
 unidecode==1.3.7
     # via iceprod
-urllib3==2.0.6
+urllib3==2.0.7
     # via
     #   botocore
     #   requests
     #   wipac-rest-tools
-wipac-dev-tools==1.7.0
+wipac-dev-tools==1.8.2
     # via
     #   iceprod
     #   wipac-rest-tools
@@ -219,7 +220,7 @@ wipac-rest-tools[telemetry]==1.5.3
     #   wipac-file-catalog-indexer (setup.py)
 wipac-telemetry==0.3.0
     # via wipac-rest-tools
-wrapt==1.15.0
+wrapt==1.16.0
     # via deprecated
 xmltodict==0.13.0
     # via wipac-file-catalog-indexer (setup.py)


### PR DESCRIPTION
Looks like I broke it in #60 when I removed a return statement.

This adds the return statement back in (minus the return value, which no longer exists).
This restores the intended short-circuit behavior, so that we don't POST / PATCH the File Catalog during a dry run.
